### PR TITLE
Ensure this addon is included before ember-cli-htmlbars

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": "ember-cli-htmlbars"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
Ensures this addon runs before ember-cli-htmlbars in order to configure
its options.