### PR TITLE
Fix class-based template literal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,10 @@ the template to the `static template` property of the class:
 
 ```js
 // components/hello.js
+import Component from '@glimmer/component';
 import { hbs } from 'ember-template-imports';
 
-export default class Hello {
+export default class Hello extends Component {
   name = 'world';
 
   static template = hbs`


### PR DESCRIPTION
The class-based template literal example was not extending a component class.