### PR TITLE
Run before ember-cli-typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,10 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "before": "ember-cli-htmlbars"
+    "before": [
+      "ember-cli-htmlbars",
+      "ember-cli-typescript"
+    ]
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
This change is to allow apps using typescript using `ember-cli-typescript` to use this addon.

Helps with #14. 