### PR TITLE
Add TS type definition for hbs import

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -19,3 +19,4 @@
 /.node_modules.ember-try/
 /bower.json.ember-try
 /package.json.ember-try
+index.d.ts

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,3 @@
+interface TemplateFactory {}
+export function hbs(template: string): TemplateFactory;
+export function hbs(tagged: TemplateStringsArray): TemplateFactory;


### PR DESCRIPTION
Adds simple type definition for the hbs import `import { hbs } from 'ember-template-imports';`.


Helps with #14.