### PR TITLE
start a README section for editor integration links

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,14 @@ file extension, you may need to configure your editor.
 ### Visual Studio Code
 The [vscode-glimmer](https://marketplace.visualstudio.com/items?itemName=chiragpat.vscode-glimmer) plugin handles syntax highlighting for both proposed formats.
 
+### Neovim
+
+[Example Neovim Config](https://github.com/NullVoxPopuli/dotfiles/blob/master/home/.config/nvim/lua/plugins.lua#L69) with support for good highlighting of embedded templates in JS and TS, using:
+
+- https://github.com/nvim-treesitter/nvim-treesitter
+- https://github.com/alexlafroscia/tree-sitter-glimmer
+
+
 
 Contributing
 ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ So far, this addon supports two different potential formats:
     <MyComponent/>
   `;
   ```
-  
+
 For the previous version of this addon, see [this repository](https://github.com/patricklx/ember-template-imports).
 And huge thanks to @patricklx for his contributions here!
 
@@ -282,6 +282,16 @@ Installation
 ```
 ember install ember-template-imports
 ```
+
+Editor Integrations
+------------------------------------------------------------------------------
+
+To get syntax highlighting inside embedded templates and support for the GJS
+file extension, you may need to configure your editor.
+
+### Visual Studio Code
+The [vscode-glimmer](https://marketplace.visualstudio.com/items?itemName=chiragpat.vscode-glimmer) plugin handles syntax highlighting for both proposed formats.
+
 
 Contributing
 ------------------------------------------------------------------------------


### PR DESCRIPTION
I think this is a good place to link people to details on editor integrations that make it more practical to try these new syntaxes.

Thanks @nullvoxpopuli for pointing out vscode-glimmer, and I know you also may be able to add an entry here for neovim.