### PR TITLE
declare magic string dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-cli-babel-plugin-helpers": "^1.1.1",
     "ember-cli-version-checker": "^5.1.2",
     "line-column": "^1.0.2",
+    "magic-string": "^0.25.7",
     "parse-static-imports": "^1.1.0",
     "string.prototype.matchall": "^4.0.6",
     "validate-peer-dependencies": "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9110,7 +9110,7 @@ macos-release@^2.2.0:
 
 magic-string@^0.25.7:
   version "0.25.7"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
   integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
   dependencies:
     sourcemap-codec "^1.4.4"


### PR DESCRIPTION
When consuming ember-template-imports for its transform/parsing utilities in other projects, magic-string is missing.

Since magic-string is located in `src/preprocess-embedded-templates.ts`, I figure it'd be good to declare this dependency?