### PR TITLE
Correctly support multiple template parsing fn from same path

### DIFF
--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -328,6 +328,71 @@ describe('parseTemplates', function () {
 
   it('hbs`Hello!` with imports alias', function () {
     const input =
+      "import { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
+      "import theHbs from 'htmlbars-inline-precompile';\n" +
+      "import { hbs } from 'not-the-hbs-you-want';\n" +
+      'hbs`Hello!`\n' +
+      'someHbs`Howdy!`\n' +
+      'theHbs`Hi!`';
+
+    const templates = parseTemplates(input, 'foo.js', {
+      templateTag: 'template',
+      templateLiteral: [
+        {
+          importPath: 'ember-cli-htmlbars',
+          importIdentifier: 'hbs',
+        },
+        {
+          importPath: 'htmlbars-inline-precompile',
+          importIdentifier: 'default',
+        },
+      ],
+    });
+
+    const expected = [
+      {
+        end: {
+          0: '`',
+          1: undefined,
+          groups: undefined,
+          index: 172,
+          input,
+        },
+        start: {
+          0: 'someHbs`',
+          1: 'someHbs',
+          groups: undefined,
+          index: 158,
+          input,
+        },
+        tagName: 'someHbs',
+        type: 'template-literal',
+      },
+      {
+        end: {
+          0: '`',
+          1: undefined,
+          groups: undefined,
+          index: 184,
+          input,
+        },
+        start: {
+          0: 'theHbs`',
+          1: 'theHbs',
+          groups: undefined,
+          index: 174,
+          input,
+        },
+        tagName: 'theHbs',
+        type: 'template-literal',
+      },
+    ];
+
+    expect(templates).toEqual(expected);
+  });
+
+  it('with multiple identifiers for the same import path', function () {
+    const input =
       "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
       "import theHbs from 'htmlbars-inline-precompile';\n" +
       "import { hbs } from 'not-the-hbs-you-want';\n" +

--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -139,6 +139,10 @@ describe('parseTemplates', function () {
       templateLiteral: [
         {
           importPath: '@ember/template-compilation',
+          importIdentifier: 'precompileTemplate',
+        },
+        {
+          importPath: '@ember/template-compilation',
           importIdentifier: 'hbs',
         },
       ],
@@ -289,6 +293,10 @@ describe('parseTemplates', function () {
       templateLiteral: [
         {
           importPath: '@ember/template-compilation',
+          importIdentifier: 'hbs',
+        },
+        {
+          importPath: '@ember/template-compilation',
           importIdentifier: 'precompileTemplate',
         },
       ],
@@ -320,10 +328,11 @@ describe('parseTemplates', function () {
 
   it('hbs`Hello!` with imports alias', function () {
     const input =
-      "import { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
+      "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
       "import theHbs from 'htmlbars-inline-precompile';\n" +
       "import { hbs } from 'not-the-hbs-you-want';\n" +
       'hbs`Hello!`\n' +
+      'someDefaultHbs`Hello!`\n' +
       'someHbs`Howdy!`\n' +
       'theHbs`Hi!`';
 
@@ -333,6 +342,10 @@ describe('parseTemplates', function () {
         {
           importPath: 'ember-cli-htmlbars',
           importIdentifier: 'hbs',
+        },
+        {
+          importPath: 'ember-cli-htmlbars',
+          importIdentifier: 'default',
         },
         {
           importPath: 'htmlbars-inline-precompile',
@@ -347,14 +360,32 @@ describe('parseTemplates', function () {
           0: '`',
           1: undefined,
           groups: undefined,
-          index: 172,
+          index: 195,
+          input,
+        },
+        start: {
+          0: 'someDefaultHbs`',
+          1: 'someDefaultHbs',
+          groups: undefined,
+          index: 174,
+          input,
+        },
+        tagName: 'someDefaultHbs',
+        type: 'template-literal',
+      },
+      {
+        end: {
+          0: '`',
+          1: undefined,
+          groups: undefined,
+          index: 211,
           input,
         },
         start: {
           0: 'someHbs`',
           1: 'someHbs',
           groups: undefined,
-          index: 158,
+          index: 197,
           input,
         },
         tagName: 'someHbs',
@@ -365,14 +396,14 @@ describe('parseTemplates', function () {
           0: '`',
           1: undefined,
           groups: undefined,
-          index: 184,
+          index: 223,
           input,
         },
         start: {
           0: 'theHbs`',
           1: 'theHbs',
           groups: undefined,
-          index: 174,
+          index: 213,
           input,
         },
         tagName: 'theHbs',

--- a/src/parse-templates.ts
+++ b/src/parse-templates.ts
@@ -370,16 +370,17 @@ function findImportedNames(
       $import.moduleName
     );
     if (config) {
-      const { importIdentifier } = config;
-      if (importIdentifier === 'default' && $import.defaultImport) {
+      const importIdentifiers = config.map(
+        ({ importIdentifier }) => importIdentifier
+      );
+      if ($import.defaultImport && importIdentifiers.includes('default')) {
         importedNames.push($import.defaultImport);
-      } else {
-        const match = $import.namedImports.find(
-          ({ name }) => name === importIdentifier
-        );
-        if (match) {
-          importedNames.push(match.alias || match.name);
-        }
+      }
+      const match = $import.namedImports.find(({ name }) =>
+        importIdentifiers.includes(name)
+      );
+      if (match) {
+        importedNames.push(match.alias || match.name);
       }
     }
   }
@@ -389,6 +390,6 @@ function findImportedNames(
 function findImportConfigByImportPath(
   importConfig: StaticImportConfig[],
   importPath: string
-): StaticImportConfig | undefined {
-  return importConfig.find((config) => config.importPath === importPath);
+): StaticImportConfig[] | undefined {
+  return importConfig.filter((config) => config.importPath === importPath);
 }


### PR DESCRIPTION
As I was working on https://github.com/ember-template-lint/ember-template-lint/pull/2483 I realized a bug is present in the existing `parseTemplate` logic. If two configurations exist for multiple identifiers coming from the same package, only one would be found. For example given the following configuration:

```
templateLiteral: [
      {
        importPath: '@ember/template-compilation',
        importIdentifier: 'hbs',
      },
      {
        importPath: '@ember/template-compilation',
        importIdentifier: 'precompileTemplate',
      },
    ],
```
The following template would be properly parsed:
```
import { hbs } from '@ember/template-compilation';
hbs`Hello!`
```
But the following template would be not be properly parsed:
```
import { precompileTemplate } from '@ember/template-compilation';
precompileTemplate`Hello!`
```

Tested this manually by applying these changes locally to https://github.com/ember-template-lint/ember-template-lint/pull/2483 and updated unit tests.