### PR TITLE
TemplateLiteralMatch populates its own importPath and importIdentifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v3.0.1 (2022-06-07)
+
+#### :bug: Bug Fix
+* [#41](https://github.com/ember-template-imports/ember-template-imports/pull/41) Correctly support multiple template parsing fn from same path ([@ventuno](https://github.com/ventuno))
+
+#### :house: Internal
+* [#40](https://github.com/ember-template-imports/ember-template-imports/pull/40) Improve parallelization in CI ([@chriskrycho](https://github.com/chriskrycho))
+
+#### Committers: 2
+- Chris Krycho ([@chriskrycho](https://github.com/chriskrycho))
+- [@ventuno](https://github.com/ventuno)
+
+
 ## v3.0.0 (2022-05-18)
 
 #### :boom: Breaking Change

--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -328,6 +328,71 @@ describe('parseTemplates', function () {
 
   it('hbs`Hello!` with imports alias', function () {
     const input =
+      "import { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
+      "import theHbs from 'htmlbars-inline-precompile';\n" +
+      "import { hbs } from 'not-the-hbs-you-want';\n" +
+      'hbs`Hello!`\n' +
+      'someHbs`Howdy!`\n' +
+      'theHbs`Hi!`';
+
+    const templates = parseTemplates(input, 'foo.js', {
+      templateTag: 'template',
+      templateLiteral: [
+        {
+          importPath: 'ember-cli-htmlbars',
+          importIdentifier: 'hbs',
+        },
+        {
+          importPath: 'htmlbars-inline-precompile',
+          importIdentifier: 'default',
+        },
+      ],
+    });
+
+    const expected = [
+      {
+        end: {
+          0: '`',
+          1: undefined,
+          groups: undefined,
+          index: 172,
+          input,
+        },
+        start: {
+          0: 'someHbs`',
+          1: 'someHbs',
+          groups: undefined,
+          index: 158,
+          input,
+        },
+        tagName: 'someHbs',
+        type: 'template-literal',
+      },
+      {
+        end: {
+          0: '`',
+          1: undefined,
+          groups: undefined,
+          index: 184,
+          input,
+        },
+        start: {
+          0: 'theHbs`',
+          1: 'theHbs',
+          groups: undefined,
+          index: 174,
+          input,
+        },
+        tagName: 'theHbs',
+        type: 'template-literal',
+      },
+    ];
+
+    expect(templates).toEqual(expected);
+  });
+
+  it('with multiple identifiers for the same import path', function () {
+    const input =
       "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
       "import theHbs from 'htmlbars-inline-precompile';\n" +
       "import { hbs } from 'not-the-hbs-you-want';\n" +

--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -139,6 +139,10 @@ describe('parseTemplates', function () {
       templateLiteral: [
         {
           importPath: '@ember/template-compilation',
+          importIdentifier: 'precompileTemplate',
+        },
+        {
+          importPath: '@ember/template-compilation',
           importIdentifier: 'hbs',
         },
       ],
@@ -289,6 +293,10 @@ describe('parseTemplates', function () {
       templateLiteral: [
         {
           importPath: '@ember/template-compilation',
+          importIdentifier: 'hbs',
+        },
+        {
+          importPath: '@ember/template-compilation',
           importIdentifier: 'precompileTemplate',
         },
       ],
@@ -320,10 +328,11 @@ describe('parseTemplates', function () {
 
   it('hbs`Hello!` with imports alias', function () {
     const input =
-      "import { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
+      "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
       "import theHbs from 'htmlbars-inline-precompile';\n" +
       "import { hbs } from 'not-the-hbs-you-want';\n" +
       'hbs`Hello!`\n' +
+      'someDefaultHbs`Hello!`\n' +
       'someHbs`Howdy!`\n' +
       'theHbs`Hi!`';
 
@@ -333,6 +342,10 @@ describe('parseTemplates', function () {
         {
           importPath: 'ember-cli-htmlbars',
           importIdentifier: 'hbs',
+        },
+        {
+          importPath: 'ember-cli-htmlbars',
+          importIdentifier: 'default',
         },
         {
           importPath: 'htmlbars-inline-precompile',
@@ -347,14 +360,32 @@ describe('parseTemplates', function () {
           0: '`',
           1: undefined,
           groups: undefined,
-          index: 172,
+          index: 195,
+          input,
+        },
+        start: {
+          0: 'someDefaultHbs`',
+          1: 'someDefaultHbs',
+          groups: undefined,
+          index: 174,
+          input,
+        },
+        tagName: 'someDefaultHbs',
+        type: 'template-literal',
+      },
+      {
+        end: {
+          0: '`',
+          1: undefined,
+          groups: undefined,
+          index: 211,
           input,
         },
         start: {
           0: 'someHbs`',
           1: 'someHbs',
           groups: undefined,
-          index: 158,
+          index: 197,
           input,
         },
         tagName: 'someHbs',
@@ -365,14 +396,14 @@ describe('parseTemplates', function () {
           0: '`',
           1: undefined,
           groups: undefined,
-          index: 184,
+          index: 223,
           input,
         },
         start: {
           0: 'theHbs`',
           1: 'theHbs',
           groups: undefined,
-          index: 174,
+          index: 213,
           input,
         },
         tagName: 'theHbs',

--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -79,6 +79,8 @@ describe('parseTemplates', function () {
             "index": 10,
             "input": "hbs\`Hello!\`",
           },
+          "importIdentifier": "hbs",
+          "importPath": undefined,
           "start": Object {
             "0": "hbs\`",
             "1": "hbs",
@@ -116,6 +118,8 @@ describe('parseTemplates', function () {
             "index": 52,
             "input": "${input}",
           },
+          "importIdentifier": "hbs",
+          "importPath": "ember-cli-htmlbars",
           "start": Object {
             "0": "hbs\`",
             "1": "hbs",
@@ -158,6 +162,8 @@ describe('parseTemplates', function () {
             "index": 61,
             "input": "${input}",
           },
+          "importIdentifier": "hbs",
+          "importPath": "@ember/template-compilation",
           "start": Object {
             "0": "hbs\`",
             "1": "hbs",
@@ -195,6 +201,8 @@ describe('parseTemplates', function () {
             "index": 56,
             "input": "${input}",
           },
+          "importIdentifier": "hbs",
+          "importPath": "ember-template-imports",
           "start": Object {
             "0": "hbs\`",
             "1": "hbs",
@@ -233,6 +241,8 @@ describe('parseTemplates', function () {
             "index": 72,
             "input": "${input}",
           },
+          "importIdentifier": "theHbs",
+          "importPath": "ember-cli-htmlbars-inline-precompile",
           "start": Object {
             "0": "theHbs\`",
             "1": "theHbs",
@@ -270,6 +280,8 @@ describe('parseTemplates', function () {
             "index": 56,
             "input": "${input}",
           },
+          "importIdentifier": "hbs",
+          "importPath": "htmlbars-inline-precompile",
           "start": Object {
             "0": "hbs\`",
             "1": "hbs",
@@ -312,6 +324,8 @@ describe('parseTemplates', function () {
             "index": 91,
             "input": "${input}",
           },
+          "importIdentifier": "precompileTemplate",
+          "importPath": "@ember/template-compilation",
           "start": Object {
             "0": "precompileTemplate\`",
             "1": "precompileTemplate",
@@ -358,6 +372,8 @@ describe('parseTemplates', function () {
           index: 172,
           input,
         },
+        importIdentifier: 'someHbs',
+        importPath: 'ember-cli-htmlbars',
         start: {
           0: 'someHbs`',
           1: 'someHbs',
@@ -376,6 +392,8 @@ describe('parseTemplates', function () {
           index: 184,
           input,
         },
+        importIdentifier: 'theHbs',
+        importPath: 'htmlbars-inline-precompile',
         start: {
           0: 'theHbs`',
           1: 'theHbs',
@@ -428,6 +446,8 @@ describe('parseTemplates', function () {
           index: 195,
           input,
         },
+        importIdentifier: 'someDefaultHbs',
+        importPath: 'ember-cli-htmlbars',
         start: {
           0: 'someDefaultHbs`',
           1: 'someDefaultHbs',
@@ -446,6 +466,8 @@ describe('parseTemplates', function () {
           index: 211,
           input,
         },
+        importIdentifier: 'someHbs',
+        importPath: 'ember-cli-htmlbars',
         start: {
           0: 'someHbs`',
           1: 'someHbs',
@@ -464,6 +486,8 @@ describe('parseTemplates', function () {
           index: 223,
           input,
         },
+        importIdentifier: 'theHbs',
+        importPath: 'htmlbars-inline-precompile',
         start: {
           0: 'theHbs`',
           1: 'theHbs',
@@ -505,6 +529,8 @@ describe('parseTemplates', function () {
           index: 123,
           input,
         },
+        importIdentifier: 'someHbs',
+        importPath: 'ember-cli-htmlbars',
         start: {
           0: 'someHbs`',
           1: 'someHbs',
@@ -534,6 +560,8 @@ describe('parseTemplates', function () {
             "0": "\`",
             "index": 10,
           },
+          "importIdentifier": "lol",
+          "importPath": undefined,
           "start": Object {
             "0": "lol\`",
             "1": "lol",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-template-imports",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"

--- a/src/parse-templates.ts
+++ b/src/parse-templates.ts
@@ -370,16 +370,17 @@ function findImportedNames(
       $import.moduleName
     );
     if (config) {
-      const { importIdentifier } = config;
-      if (importIdentifier === 'default' && $import.defaultImport) {
+      const importIdentifiers = config.map(
+        ({ importIdentifier }) => importIdentifier
+      );
+      if ($import.defaultImport && importIdentifiers.includes('default')) {
         importedNames.push($import.defaultImport);
-      } else {
-        const match = $import.namedImports.find(
-          ({ name }) => name === importIdentifier
-        );
-        if (match) {
-          importedNames.push(match.alias || match.name);
-        }
+      }
+      const match = $import.namedImports.find(({ name }) =>
+        importIdentifiers.includes(name)
+      );
+      if (match) {
+        importedNames.push(match.alias || match.name);
       }
     }
   }
@@ -389,6 +390,6 @@ function findImportedNames(
 function findImportConfigByImportPath(
   importConfig: StaticImportConfig[],
   importPath: string
-): StaticImportConfig | undefined {
-  return importConfig.find((config) => config.importPath === importPath);
+): StaticImportConfig[] | undefined {
+  return importConfig.filter((config) => config.importPath === importPath);
 }


### PR DESCRIPTION
This is a PoC of how to do #42 and help unblock template imports in ember-template-lint.

* My approach populates the import path and the import name in a `TemplateLiteralMatch`. The only needed change was to switch `importedNames` from an array to a map so we keep the association between import name and path.

cc: @rwjblue @chriskrycho 