### PR TITLE
Stop trying to tokenize regexes to avoid confusing bug caused by division appearing in a file before a <template> tag

### DIFF
--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -62,6 +62,91 @@ describe('parseTemplates', function () {
     `);
   });
 
+  it('<template></template> preceded by a slash character', function () {
+    const input = `
+      const divide = () => 4 / 2;
+      <template>Hello!</template>
+    `;
+
+    const templates = parseTemplates(input, 'foo.gjs', {
+      templateTag: 'template',
+    });
+
+    expect(templates).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "end": Object {
+            "0": "</template>",
+            "1": undefined,
+            "groups": undefined,
+            "index": 57,
+            "input": "
+            const divide = () => 4 / 2;
+            <template>Hello!</template>
+          ",
+          },
+          "start": Object {
+            "0": "<template>",
+            "1": undefined,
+            "groups": undefined,
+            "index": 41,
+            "input": "
+            const divide = () => 4 / 2;
+            <template>Hello!</template>
+          ",
+          },
+          "type": "template-tag",
+        },
+      ]
+    `);
+  });
+
+  // This test demonstrates a problem with the current implementation. The characters "<template>"
+  // inside of a regex is treated as an opening template tag instead of being ignored. Previous
+  // versions of this addon attempted to address this by parsing "/"-delimited regexes, however
+  // the addon's regular-expression based tokenizing was unable to properly distinguish a regex
+  // from division, and so the test above this one ("<template></template> preceded by a slash
+  // character") did not pass and caused quite confusing failures that occurred far more
+  // frequently than the issue demonstrated below will occur.
+  it.skip('<template></template> with <template> inside of a regexp', function () {
+    const input = `
+      const myregex = /<template>/;
+      <template>Hello!</template>
+    `;
+
+    const templates = parseTemplates(input, 'foo.gjs', {
+      templateTag: 'template',
+    });
+
+    expect(templates).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "end": Object {
+            "0": "</template>",
+            "1": undefined,
+            "groups": undefined,
+            "index": 9,
+            "input": "
+            const myregex = /<template>/;
+            <template>Hello!</template>
+          ",
+          },
+          "start": Object {
+            "0": "<template>",
+            "1": undefined,
+            "groups": undefined,
+            "index": 43,
+            "input": "
+            const myregex = /<template>/;
+            <template>Hello!</template>
+          ",
+          },
+          "type": "template-tag",
+        },
+      ]
+    `);
+  });
+
   it('hbs`Hello!` when only matching <template>', function () {
     const input = 'hbs`Hello!`';
 

--- a/src/parse-templates.ts
+++ b/src/parse-templates.ts
@@ -49,7 +49,7 @@ export interface ParseTemplatesOptions {
 }
 
 const escapeChar = '\\';
-const stringOrRegexDelimiter = /['"/]/;
+const stringDelimiter = /['"]/;
 
 const singleLineCommentStart = /\/\//;
 const newLine = /\n/;
@@ -119,7 +119,7 @@ export function parseTemplates(
       newLine.source,
       multiLineCommentStart.source,
       multiLineCommentEnd.source,
-      stringOrRegexDelimiter.source,
+      stringDelimiter.source,
       templateLiteralStart.source,
       templateLiteralEnd.source,
       dynamicSegmentStart.source,
@@ -170,16 +170,16 @@ export function parseTemplates(
       token[0].match(templateTagStart)
     ) {
       parseTemplateTag(results, template, token, tokens);
-    } else if (token[0].match(stringOrRegexDelimiter)) {
-      parseStringOrRegex(results, template, token, tokens);
+    } else if (token[0].match(stringDelimiter)) {
+      parseString(results, template, token, tokens);
     }
   }
 
   /**
-   * Parse a string or a regex. All tokens within a string or regex are ignored
+   * Parse a string. All tokens within a string are ignored
    * since there are no dynamic segments within these.
    */
-  function parseStringOrRegex(
+  function parseString(
     _results: TemplateMatch[],
     template: string,
     startToken: RegExpMatchArray,

--- a/tests/integration/gjs-test.gjs
+++ b/tests/integration/gjs-test.gjs
@@ -52,8 +52,26 @@ module('tests/integration/components/gjs', function (hooks) {
         scope: () => ({ Foo }),
       })
     );
-
     assert.equal(this.element.textContent.trim(), 'Hello, `lifeform`!');
+  });
+
+test('it works with classes with a slash character somewhere before the template', async function (assert) {
+    class Foo extends Component {
+      greeting = 'Hello';
+      get age() {
+        return 90 / 2;
+      }
+
+      <template>{{this.greeting}}, {{this.age}}-year-old!</template>
+    }
+
+    await render(
+      precompileTemplate(`<Foo @name="world" />`, {
+        strictMode: true,
+        scope: () => ({ Foo }),
+      })
+    );
+    assert.equal(this.element.textContent.trim(), 'Hello, 45-year-old!');
   });
 
   test('it works with a component that is a top-level default export', async function (assert) {


### PR DESCRIPTION
Stop trying to tokenize regexes to avoid confusing bug with division
The *right* way for this addon to work is via babel or something with a
proper grammar and parser. However, our current implementation relies on
tokenization via regular expression, and the attempt to tokenize regular
expressions in code causes bugs in code that does division with a slash
character. This commit removes the "/" from the tokenization and trades
the problem of division before a template tag breaking template parsing
for the much less likely problem of improperly detecting a template tag
inside a regex.

Here's an example of some code with a template that will now fail to parse:

```gjs
const myregex = /<template>/;
<template>Hello!</template>
```

And here is what previously failed but will work after this commit:

```
const divide = () => 4 / 2;
<template>Hello!</template>
```

Fixes #52 and #53 