### PR TITLE
Fix build failures due to backticks within in template tags

### DIFF
--- a/__tests__/preprocess-embedded-templates.test.ts
+++ b/__tests__/preprocess-embedded-templates.test.ts
@@ -3,7 +3,7 @@ import { getTemplateLocals } from '@glimmer/syntax';
 import * as util from '../src/util.js';
 
 describe('preprocessEmbeddedTemplates', function () {
-  it('<template><template>', function () {
+  it('<template></template>', function () {
     const input = `<template>Hello!</template>`;
     const templates = preprocessEmbeddedTemplates(input, {
       getTemplateLocals,
@@ -39,8 +39,66 @@ describe('preprocessEmbeddedTemplates', function () {
     expect(templates).toEqual(expected);
   });
 
+  it('<template></template> with backticks in content', function () {
+    const input = '<template>Hello `world`!</template>';
+    const templates = preprocessEmbeddedTemplates(input, {
+      getTemplateLocals,
+      relativePath: 'foo.gjs',
+      templateTag: util.TEMPLATE_TAG_NAME,
+      templateTagReplacement: util.TEMPLATE_TAG_PLACEHOLDER,
+      includeSourceMaps: false,
+      includeTemplateTokens: false,
+    });
+
+    const expected = {
+      output:
+        '[__GLIMMER_TEMPLATE(`Hello \\`world\\`!`, { strictMode: true })]',
+      replacements: [
+        {
+          type: 'start',
+          index: 0,
+          oldLength: 10,
+          newLength: 21,
+          originalCol: 1,
+          originalLine: 1,
+        },
+        {
+          type: 'end',
+          index: 24,
+          oldLength: 11,
+          newLength: 25,
+          originalCol: 25,
+          originalLine: 1,
+        },
+      ],
+    };
+
+    expect(templates).toEqual(expected);
+  });
+
   it('hbs`Hello`', function () {
     const input = `hbs\`Hello!\``;
+    const templates = preprocessEmbeddedTemplates(input, {
+      getTemplateLocals,
+      relativePath: 'foo.gjs',
+      templateTag: util.TEMPLATE_TAG_NAME,
+      templateTagReplacement: util.TEMPLATE_TAG_PLACEHOLDER,
+      importIdentifier: util.TEMPLATE_LITERAL_IDENTIFIER,
+      importPath: util.TEMPLATE_LITERAL_MODULE_SPECIFIER,
+      includeSourceMaps: false,
+      includeTemplateTokens: false,
+    });
+
+    const expected = {
+      output: input,
+      replacements: [],
+    };
+
+    expect(templates).toEqual(expected);
+  });
+
+  it('hbs`Hello \\`world\\``', function () {
+    const input = `hbs\`Hello \\\`world\\\`!\``; // template tag with escaped backticks in content
     const templates = preprocessEmbeddedTemplates(input, {
       getTemplateLocals,
       relativePath: 'foo.gjs',

--- a/src/preprocess-embedded-templates.ts
+++ b/src/preprocess-embedded-templates.ts
@@ -134,6 +134,7 @@ function replaceMatch(
 
   s.overwrite(openStart, openEnd, newStart);
   s.overwrite(closeStart, closeEnd, newEnd);
+  ensureBackticksEscaped(s, openEnd + 1, closeStart - 1);
 
   return [
     replacementFrom(
@@ -270,4 +271,10 @@ export function preprocessEmbeddedTemplates(
     output,
     replacements,
   };
+}
+
+function ensureBackticksEscaped(s: MagicString, start: number, end: number) {
+  let content = s.slice(start, end);
+  content = content.replace(/(?<!\\)`/g, '\\`');
+  s.overwrite(start, end, content, false);
 }

--- a/tests/integration/gjs-test.gjs
+++ b/tests/integration/gjs-test.gjs
@@ -39,6 +39,23 @@ module('tests/integration/components/gjs', function (hooks) {
     assert.equal(this.element.textContent.trim(), 'Hello, world!');
   });
 
+  test('it works with classes with a backtick character somewhere in the template', async function (assert) {
+    class Foo extends Component {
+      greeting = 'Hello';
+
+      <template>{{this.greeting}}, `lifeform`!</template>
+    }
+
+    await render(
+      precompileTemplate(`<Foo />`, {
+        strictMode: true,
+        scope: () => ({ Foo }),
+      })
+    );
+
+    assert.equal(this.element.textContent.trim(), 'Hello, `lifeform`!');
+  });
+
   test('it works with a component that is a top-level default export', async function (assert) {
     await render(
       precompileTemplate(`<GjsTest />`, {


### PR DESCRIPTION
The VSCode extension crashes in a similar fashion.

The fix does its work by ensuring that backticks within a &lt;template&gt; tag are escaped by the preprocessor. Backticks seems to be semantically fine within a template tag but since the preprocessor converts template tags to backtick-delimited template literals, they are no longer OK without escaping.