### PR TITLE
internal: set up Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily


### PR DESCRIPTION
We're *way* out of date on a lot of dependencies, because nothing has been keeping us up to date. This should help.