### PR TITLE
Do not require parent addon to include ember-cli-htmlbars

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -23,9 +23,10 @@ module.exports = {
       addPlugin(includer, pluginPath);
     }
 
-    this.templateCompilerPath = this.parent.addons
-      .find((a) => a.name === 'ember-cli-htmlbars')
-      .templateCompilerPath();
+    // Used in ember-cli-htmlbars to get the location of templateCompiler without traversing this.addons (https://github.com/ember-cli/ember-cli-htmlbars/blob/6860beed9a357d5e948abd09754e8a978fed1320/lib/ember-addon-main.js#L264)
+    let ember = this.project.findAddonByName('ember-source');
+
+    this.templateCompilerPath = ember.absolutePaths.templateCompiler;
   },
 
   setupPreprocessorRegistry(type, registry) {

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -3,6 +3,10 @@ require('validate-peer-dependencies')(__dirname);
 let VersionChecker = require('ember-cli-version-checker');
 let { addPlugin, hasPlugin } = require('ember-cli-babel-plugin-helpers');
 
+// eslint-disable-next-line node/no-unpublished-require
+const emberAddon = require('ember-source');
+const templateCompiler = emberAddon.absolutePaths.templateCompiler;
+
 module.exports = {
   name: require('./package').name,
 
@@ -23,10 +27,7 @@ module.exports = {
       addPlugin(includer, pluginPath);
     }
 
-    // Used in ember-cli-htmlbars to get the location of templateCompiler without traversing this.addons (https://github.com/ember-cli/ember-cli-htmlbars/blob/6860beed9a357d5e948abd09754e8a978fed1320/lib/ember-addon-main.js#L264)
-    let ember = this.project.findAddonByName('ember-source');
-
-    this.templateCompilerPath = ember.absolutePaths.templateCompiler;
+    this.templateCompilerPath = templateCompiler;
   },
 
   setupPreprocessorRegistry(type, registry) {

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -3,10 +3,6 @@ require('validate-peer-dependencies')(__dirname);
 let VersionChecker = require('ember-cli-version-checker');
 let { addPlugin, hasPlugin } = require('ember-cli-babel-plugin-helpers');
 
-// eslint-disable-next-line node/no-unpublished-require
-const emberAddon = require('ember-source');
-const templateCompiler = emberAddon.absolutePaths.templateCompiler;
-
 module.exports = {
   name: require('./package').name,
 
@@ -27,7 +23,10 @@ module.exports = {
       addPlugin(includer, pluginPath);
     }
 
-    this.templateCompilerPath = templateCompiler;
+    // Used in ember-cli-htmlbars to get the location of templateCompiler without traversing this.addons (https://github.com/ember-cli/ember-cli-htmlbars/blob/6860beed9a357d5e948abd09754e8a978fed1320/lib/ember-addon-main.js#L264)
+    let ember = this.project.findAddonByName('ember-source');
+
+    this.templateCompilerPath = ember.absolutePaths.templateCompiler;
   },
 
   setupPreprocessorRegistry(type, registry) {

--- a/package.json
+++ b/package.json
@@ -130,8 +130,5 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
-  },
-  "volta": {
-    "node": "14.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -130,5 +130,8 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
+  },
+  "volta": {
+    "node": "14.17.0"
   }
 }


### PR DESCRIPTION
# Summary

When adding `ember-template-imports` to my addon to parse template imports it required a hard dependency on ember-cli-htmlbars which resulted in the following error if I didn't add it to my project.

```
Cannot read properties of undefined (reading 'templateCompilerPath')


Stack Trace and Error Report: /tmp/error.dump.acbe9ab57e7c9f4a0e92b7c7d81184ae.log

Result: false
```

With this change it will use the templateCompiler provided by ember-source which passes tests and doesn't require me to add a hard dependency on ember-cli-htmlbars.