### PR TITLE
Provide the contents of the parsed template when calling `parseTemplates`

### DIFF
--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -42,7 +42,7 @@ describe('parseTemplates', function () {
     expect(templates).toMatchInlineSnapshot(`
       Array [
         Object {
-          "contents": "",
+          "contents": "Hello!",
           "end": Object {
             "0": "</template>",
             "1": undefined,

--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -42,6 +42,7 @@ describe('parseTemplates', function () {
     expect(templates).toMatchInlineSnapshot(`
       Array [
         Object {
+          "contents": "",
           "end": Object {
             "0": "</template>",
             "1": undefined,
@@ -75,6 +76,7 @@ describe('parseTemplates', function () {
     expect(templates).toMatchInlineSnapshot(`
       Array [
         Object {
+          "contents": "Hello!",
           "end": Object {
             "0": "</template>",
             "1": undefined,
@@ -173,6 +175,7 @@ describe('parseTemplates', function () {
     expect(templates).toMatchInlineSnapshot(`
       Array [
         Object {
+          "contents": "Hello!",
           "end": Object {
             "0": "\`",
             "1": undefined,
@@ -217,6 +220,7 @@ describe('parseTemplates', function () {
     expect(templates).toMatchInlineSnapshot(`
       Array [
         Object {
+          "contents": "Hello!",
           "end": Object {
             "0": "\`",
             "1": undefined,
@@ -256,6 +260,7 @@ describe('parseTemplates', function () {
     expect(templates).toMatchInlineSnapshot(`
       Array [
         Object {
+          "contents": "Hello!",
           "end": Object {
             "0": "\`",
             "1": undefined,
@@ -296,6 +301,7 @@ describe('parseTemplates', function () {
     expect(templates).toMatchInlineSnapshot(`
       Array [
         Object {
+          "contents": "Hello!",
           "end": Object {
             "0": "\`",
             "1": undefined,
@@ -335,6 +341,7 @@ describe('parseTemplates', function () {
     expect(templates).toMatchInlineSnapshot(`
       Array [
         Object {
+          "contents": "Hello!",
           "end": Object {
             "0": "\`",
             "1": undefined,
@@ -379,6 +386,7 @@ describe('parseTemplates', function () {
     expect(templates).toMatchInlineSnapshot(`
       Array [
         Object {
+          "contents": "Hello!",
           "end": Object {
             "0": "\`",
             "1": undefined,
@@ -427,6 +435,7 @@ describe('parseTemplates', function () {
 
     const expected = [
       {
+        contents: 'Howdy!',
         end: {
           0: '`',
           1: undefined,
@@ -447,6 +456,7 @@ describe('parseTemplates', function () {
         type: 'template-literal',
       },
       {
+        contents: 'Hi!',
         end: {
           0: '`',
           1: undefined,
@@ -501,6 +511,7 @@ describe('parseTemplates', function () {
 
     const expected = [
       {
+        contents: 'Hello!',
         end: {
           0: '`',
           1: undefined,
@@ -521,6 +532,7 @@ describe('parseTemplates', function () {
         type: 'template-literal',
       },
       {
+        contents: 'Howdy!',
         end: {
           0: '`',
           1: undefined,
@@ -541,6 +553,7 @@ describe('parseTemplates', function () {
         type: 'template-literal',
       },
       {
+        contents: 'Hi!',
         end: {
           0: '`',
           1: undefined,
@@ -584,6 +597,7 @@ describe('parseTemplates', function () {
 
     const expected = [
       {
+        contents: 'Howdy!',
         end: {
           0: '`',
           1: undefined,

--- a/src/parse-templates.ts
+++ b/src/parse-templates.ts
@@ -8,11 +8,13 @@ export interface TemplateTagMatch {
   type: 'template-tag';
   start: RegExpMatchArray;
   end: RegExpMatchArray;
+  contents: string;
 }
 
 export interface TemplateLiteralMatch {
   type: 'template-literal';
   tagName: string;
+  contents: string;
   start: RegExpMatchArray;
   end: RegExpMatchArray;
   importPath: string;
@@ -272,10 +274,20 @@ export function parseTemplates(
           }
           const tagName = startToken[1];
           const importConfig = importedNames.get(tagName);
+
           if (importConfig !== undefined) {
+            let contents = '';
+
+            if (startToken.index) {
+              const templateStart = startToken.index + startToken[0].length;
+
+              contents = template.slice(templateStart, currentToken.index);
+            }
+
             results.push({
               type: 'template-literal',
               tagName,
+              contents: contents,
               start: startToken,
               end: currentToken,
               importPath: importConfig.importPath,
@@ -347,8 +359,17 @@ export function parseTemplates(
       }
 
       if (stack === 0) {
+        let contents = '';
+
+        if (startToken.index) {
+          const templateStart = startToken.index + startToken[0].length;
+
+          contents = template.slice(templateStart, currentToken.index);
+        }
+
         results.push({
           type: 'template-tag',
+          contents: contents,
           start: startToken,
           end: currentToken,
         });

--- a/src/parse-templates.ts
+++ b/src/parse-templates.ts
@@ -278,7 +278,7 @@ export function parseTemplates(
           if (importConfig !== undefined) {
             let contents = '';
 
-            if (startToken.index) {
+            if (startToken.index !== undefined) {
               const templateStart = startToken.index + startToken[0].length;
 
               contents = template.slice(templateStart, currentToken.index);
@@ -361,7 +361,7 @@ export function parseTemplates(
       if (stack === 0) {
         let contents = '';
 
-        if (startToken.index) {
+        if (startToken.index !== undefined) {
           const templateStart = startToken.index + startToken[0].length;
 
           contents = template.slice(templateStart, currentToken.index);


### PR DESCRIPTION
# Summary

Provides a way to get the contents of the parsed template string to avoid doing the last work in consuming libraries such as https://github.com/ember-template-lint/ember-template-lint/blob/9e998527cd0e495e750650f2fc73a24fd0c29fa7/lib/extract-templates.js#L64. 

