### PR TITLE
Bring back `src/utils.js` temporarily

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -15,6 +15,7 @@
 /coverage/
 !.*
 .eslintcache
+/.git/
 
 # ember-try
 /.node_modules.ember-try/

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,6 @@
+// ember-template-lint@4.14.0 landed a direct import of this file as `import * as util from 'ember-template-imports/src/util.js';`
+// in order to prevent users from getting errors when getting a floating version of `ember-template-imports` that includes this file
+// being rewritting in `.ts` we need to re-export from `lib/utils.js`.
+//
+// TODO: this should be removed in the next major version
+module.exports = require('../lib/util');


### PR DESCRIPTION
ember-template-lint@4.14.0 landed a direct import of this file as `import * as util from 'ember-template-imports/src/util.js';` (in https://github.com/ember-template-lint/ember-template-lint/pull/2483), but https://github.com/ember-template-imports/ember-template-imports/pull/75 removed `src/utils.js` (migrating it to TypeScript).

In order to prevent users from getting errors when getting a floating version of `ember-template-imports` that includes this file being rewritting in `.ts` we need to re-export from `lib/utils.js`.

This should be removed in the next major version
