### PR TITLE
feat: adds default exports to avoid importing from nested paths

### DIFF
--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -589,7 +589,11 @@ describe('parseTemplates', function () {
       'someHbs`Howdy!`\n' +
       'theHbs`Hi!`';
 
-    const templates = parseTemplates(input, 'foo.js', DEFAULT_PARSE_TEMPLATES_OPTIONS);
+    const templates = parseTemplates(
+      input,
+      'foo.js',
+      DEFAULT_PARSE_TEMPLATES_OPTIONS
+    );
 
     expect(templates).toMatchInlineSnapshot(`
       Array [

--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -1,6 +1,7 @@
 import {
   parseTemplates as _parseTemplates,
   ParseTemplatesOptions,
+  DEFAULT_PARSE_OPTIONS,
 } from '../src/parse-templates';
 
 describe('parseTemplates', function () {
@@ -576,6 +577,90 @@ describe('parseTemplates', function () {
     ];
 
     expect(templates).toEqual(expected);
+  });
+
+  it('with multiple identifiers for the same import path', function () {
+    const input =
+      "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
+      "import theHbs from 'htmlbars-inline-precompile';\n" +
+      "import { hbs } from 'not-the-hbs-you-want';\n" +
+      'hbs`Hello!`\n' +
+      'someDefaultHbs`Hello!`\n' +
+      'someHbs`Howdy!`\n' +
+      'theHbs`Hi!`';
+
+    const templates = parseTemplates(input, 'foo.js', DEFAULT_PARSE_OPTIONS);
+
+    expect(templates).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "contents": "Howdy!",
+          "end": Object {
+            "0": "\`",
+            "1": undefined,
+            "groups": undefined,
+            "index": 211,
+            "input": "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';
+      import theHbs from 'htmlbars-inline-precompile';
+      import { hbs } from 'not-the-hbs-you-want';
+      hbs\`Hello!\`
+      someDefaultHbs\`Hello!\`
+      someHbs\`Howdy!\`
+      theHbs\`Hi!\`",
+          },
+          "importIdentifier": "hbs",
+          "importPath": "ember-cli-htmlbars",
+          "start": Object {
+            "0": "someHbs\`",
+            "1": "someHbs",
+            "groups": undefined,
+            "index": 197,
+            "input": "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';
+      import theHbs from 'htmlbars-inline-precompile';
+      import { hbs } from 'not-the-hbs-you-want';
+      hbs\`Hello!\`
+      someDefaultHbs\`Hello!\`
+      someHbs\`Howdy!\`
+      theHbs\`Hi!\`",
+          },
+          "tagName": "someHbs",
+          "type": "template-literal",
+        },
+        Object {
+          "contents": "Hi!",
+          "end": Object {
+            "0": "\`",
+            "1": undefined,
+            "groups": undefined,
+            "index": 223,
+            "input": "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';
+      import theHbs from 'htmlbars-inline-precompile';
+      import { hbs } from 'not-the-hbs-you-want';
+      hbs\`Hello!\`
+      someDefaultHbs\`Hello!\`
+      someHbs\`Howdy!\`
+      theHbs\`Hi!\`",
+          },
+          "importIdentifier": "default",
+          "importPath": "htmlbars-inline-precompile",
+          "start": Object {
+            "0": "theHbs\`",
+            "1": "theHbs",
+            "groups": undefined,
+            "index": 213,
+            "input": "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';
+      import theHbs from 'htmlbars-inline-precompile';
+      import { hbs } from 'not-the-hbs-you-want';
+      hbs\`Hello!\`
+      someDefaultHbs\`Hello!\`
+      someHbs\`Howdy!\`
+      theHbs\`Hi!\`",
+          },
+          "tagName": "theHbs",
+          "type": "template-literal",
+        },
+      ]
+    `);
   });
 
   it('hbs`Hello!` with multiple imports and alias', function () {

--- a/__tests__/parse-templates.test.ts
+++ b/__tests__/parse-templates.test.ts
@@ -1,7 +1,7 @@
 import {
   parseTemplates as _parseTemplates,
   ParseTemplatesOptions,
-  DEFAULT_PARSE_OPTIONS,
+  DEFAULT_PARSE_TEMPLATES_OPTIONS,
 } from '../src/parse-templates';
 
 describe('parseTemplates', function () {
@@ -579,7 +579,7 @@ describe('parseTemplates', function () {
     expect(templates).toEqual(expected);
   });
 
-  it('with multiple identifiers for the same import path', function () {
+  it('with multiple identifiers for the same import path with DEFAULT_PARSE_TEMPLATES_OPTIONS', function () {
     const input =
       "import someDefaultHbs, { hbs as someHbs } from 'ember-cli-htmlbars';\n" +
       "import theHbs from 'htmlbars-inline-precompile';\n" +
@@ -589,7 +589,7 @@ describe('parseTemplates', function () {
       'someHbs`Howdy!`\n' +
       'theHbs`Hi!`';
 
-    const templates = parseTemplates(input, 'foo.js', DEFAULT_PARSE_OPTIONS);
+    const templates = parseTemplates(input, 'foo.js', DEFAULT_PARSE_TEMPLATES_OPTIONS);
 
     expect(templates).toMatchInlineSnapshot(`
       Array [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,5 @@
-export { parseTemplates, DEFAULT_PARSE_OPTIONS } from './parse-templates';
 export {
-  isStrictMode,
-  isSupportedScriptFileExtension,
-  TEMPLATE_TAG_NAME,
-  TEMPLATE_LITERAL_MODULE_SPECIFIER,
-  TEMPLATE_LITERAL_IDENTIFIER,
-} from './util';
+  parseTemplates,
+  DEFAULT_PARSE_TEMPLATES_OPTIONS,
+} from './parse-templates';
+export { isStrictMode, isSupportedScriptFileExtension } from './util';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,8 @@
-export { parseTemplates } from './parse-templates';
+export { parseTemplates, DEFAULT_PARSE_OPTIONS } from './parse-templates';
+export {
+  isStrictMode,
+  isSupportedScriptFileExtension,
+  TEMPLATE_TAG_NAME,
+  TEMPLATE_LITERAL_MODULE_SPECIFIER,
+  TEMPLATE_LITERAL_IDENTIFIER,
+} from './util';

--- a/src/parse-templates.ts
+++ b/src/parse-templates.ts
@@ -1,6 +1,12 @@
 import matchAll from 'string.prototype.matchall';
-import { expect } from './debug';
 import parseStaticImports from 'parse-static-imports';
+
+import {
+  TEMPLATE_TAG_NAME,
+  TEMPLATE_LITERAL_MODULE_SPECIFIER,
+  TEMPLATE_LITERAL_IDENTIFIER,
+} from './util';
+import { expect } from './debug';
 
 export type TemplateMatch = TemplateTagMatch | TemplateLiteralMatch;
 
@@ -83,6 +89,36 @@ function isEscaped(template: string, _offset: number | undefined) {
 
   return count % 2 === 1;
 }
+
+export const DEFAULT_PARSE_OPTIONS = {
+  templateTag: TEMPLATE_TAG_NAME,
+  templateLiteral: [
+    {
+      importPath: 'ember-cli-htmlbars',
+      importIdentifier: 'hbs',
+    },
+    {
+      importPath: '@ember/template-compilation',
+      importIdentifier: 'hbs',
+    },
+    {
+      importPath: TEMPLATE_LITERAL_MODULE_SPECIFIER,
+      importIdentifier: TEMPLATE_LITERAL_IDENTIFIER,
+    },
+    {
+      importPath: 'ember-cli-htmlbars-inline-precompile',
+      importIdentifier: 'default',
+    },
+    {
+      importPath: 'htmlbars-inline-precompile',
+      importIdentifier: 'default',
+    },
+    {
+      importPath: '@ember/template-compilation',
+      importIdentifier: 'precompileTemplate',
+    },
+  ],
+};
 
 /**
  * Parses a template to find all possible valid matches for an embedded template.

--- a/src/parse-templates.ts
+++ b/src/parse-templates.ts
@@ -90,7 +90,7 @@ function isEscaped(template: string, _offset: number | undefined) {
   return count % 2 === 1;
 }
 
-export const DEFAULT_PARSE_OPTIONS = {
+export const DEFAULT_PARSE_TEMPLATES_OPTIONS = {
   templateTag: TEMPLATE_TAG_NAME,
   templateLiteral: [
     {
@@ -142,7 +142,7 @@ export const DEFAULT_PARSE_OPTIONS = {
 export function parseTemplates(
   template: string,
   relativePath: string,
-  options?: ParseTemplatesOptions
+  options: ParseTemplatesOptions = DEFAULT_PARSE_TEMPLATES_OPTIONS
 ): TemplateMatch[] {
   const results: TemplateMatch[] = [];
   const templateTag = options?.templateTag;


### PR DESCRIPTION
# Summary

https://github.com/ember-template-lint/ember-template-lint/blob/2ba29bd8dbbf052d91e874137a3dcd3ccc0c96ca/lib/extract-templates.js#L1 uses nested paths to import functionality. I have hoisted that to a default export so that multiple consumers don't have to worry about the internal organization of the project.