### PR TITLE
Remove ember-cli-htmlbars from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "string.prototype.matchall": "^4.0.6",
     "validate-peer-dependencies": "^1.1.0"
   },
-  "peerDependencies": {
-    "ember-cli-htmlbars": "^6.0.0"
-  },
   "devDependencies": {
     "@babel/traverse": "^7.19.6",
     "@babel/types": "^7.19.4",


### PR DESCRIPTION
This is follow up to #73 and per https://github.com/ember-template-imports/ember-template-imports/pull/73#issuecomment-1317282143