### PR TITLE
Update to support only Node 16 and 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - 'v*'
   pull_request: {}
   schedule:
-  - cron:  '0 6 * * 0' # weekly, on sundays
+    - cron: '0 6 * * 0' # weekly, on sundays
 
 jobs:
   lint:
@@ -15,18 +15,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: install dependencies
-      run: yarn install
-    - name: build
-      run: yarn build
-    - name: lint:js
-      run: yarn lint:js
-    - name: lint:hbs
-      run: yarn lint:hbs
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: install dependencies
+        run: yarn install
+      - name: build
+        run: yarn build
+      - name: lint:js
+        run: yarn lint:js
+      - name: lint:hbs
+        run: yarn lint:hbs
 
   # Basic tests; we can trigger parallel runs of *everything else* iff this
   # passes.
@@ -35,24 +35,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: install dependencies
-      # Dependency fetching in Windows Actions runners can be slow
-      run: yarn install --network-timeout 60000
-    - name: build
-      run: yarn build
-    - name: jest
-      run: yarn test:jest
-    - name: ember test
-      run: yarn test:ember
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: install dependencies
+        # Dependency fetching in Windows Actions runners can be slow
+        run: yarn install --network-timeout 60000
+      - name: build
+        run: yarn build
+      - name: jest
+        run: yarn test:jest
+      - name: ember test
+        run: yarn test:ember
 
   # For example: don't bother with *other* Node version tests unless the base
   # case passes!
   tests-node:
-    name: "Tests: Node ${{ matrix.node-version }}"
+    name: 'Tests: Node ${{ matrix.node-version }}'
     runs-on: ubuntu-latest
 
     needs: [test, lint]
@@ -60,25 +60,25 @@ jobs:
     strategy:
       matrix:
         node-version: [14.x, 16.x]
-    
+
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: install dependencies
-      # Dependency fetching in Windows Actions runners can be slow
-      run: yarn install --network-timeout 60000
-    - name: build
-      run: yarn build
-    - name: jest
-      run: yarn test:jest
-    - name: ember test
-      run: yarn test:ember
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: install dependencies
+        # Dependency fetching in Windows Actions runners can be slow
+        run: yarn install --network-timeout 60000
+      - name: build
+        run: yarn build
+      - name: jest
+        run: yarn test:jest
+      - name: ember test
+        run: yarn test:ember
 
   # macOS and Windows can run after we clear ubuntu (don't bother otherwise)
   test-other-os:
-    name: "Tests: ${{ matrix.os }}"
+    name: 'Tests: ${{ matrix.os }}'
     runs-on: ${{ matrix.os }}-latest
 
     needs: [test, lint]
@@ -88,19 +88,19 @@ jobs:
         os: [macos, windows]
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: install dependencies
-      # Dependency fetching in Windows Actions runners can be slow
-      run: yarn install --network-timeout 60000
-    - name: build
-      run: yarn build
-    - name: jest
-      run: yarn test:jest
-    - name: ember test
-      run: yarn test:ember
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: install dependencies
+        # Dependency fetching in Windows Actions runners can be slow
+        run: yarn install --network-timeout 60000
+      - name: build
+        run: yarn build
+      - name: jest
+        run: yarn test:jest
+      - name: ember test
+        run: yarn test:ember
 
   # floating deps likewise are only gated on ubuntu tests passing
   floating-dependencies:
@@ -110,18 +110,18 @@ jobs:
     needs: [test, lint]
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: install dependencies
-      run: yarn install --ignore-lockfile
-    - name: build
-      run: yarn build
-    - name: jest
-      run: yarn test:jest
-    - name: ember test
-      run: yarn test:ember
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: install dependencies
+        run: yarn install --ignore-lockfile
+      - name: build
+        run: yarn build
+      - name: jest
+        run: yarn test:jest
+      - name: ember test
+        run: yarn test:ember
 
   # as are other compatibility scenarios
   try-scenarios:
@@ -134,23 +134,23 @@ jobs:
     strategy:
       matrix:
         ember-try-scenario:
-         - ember-3.27
-         - ember-release
-         - ember-beta
-         - ember-canary
-         - embroider-safe
-         - embroider-optimized
+          - ember-3.27
+          - ember-release
+          - ember-beta
+          - ember-canary
+          - embroider-safe
+          - embroider-optimized
 
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
-    - name: install dependencies
-      run: yarn install
-    - name: build
-      run: yarn build
-    - name: test
-      env:
-        EMBER_TRY_SCENARIO: ${{ matrix.ember-try-scenario }}
-      run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+      - name: install dependencies
+        run: yarn install
+      - name: build
+        run: yarn build
+      - name: test
+        env:
+          EMBER_TRY_SCENARIO: ${{ matrix.ember-try-scenario }}
+        run: node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@babel/generator": "~7.16.0"
   },
   "engines": {
-    "node": "12.* || >= 14"
+    "node": "16.* || >= 18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
We could continue to support Node 14... for one whole month. But then we'd be setting ourselves up to make another breaking change to drop support for it at the end of April or early May. Instead, just do this once and go all the way to 16 and 18.