### PR TITLE
Add aggregate deprecation about hbs

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -1,7 +1,10 @@
 'use strict';
 require('validate-peer-dependencies')(__dirname);
+
+let stew = require('broccoli-stew');
 let VersionChecker = require('ember-cli-version-checker');
 let { addPlugin, hasPlugin } = require('ember-cli-babel-plugin-helpers');
+const { maybePrintHbsDeprecation } = require('./src/hbs-deprecation');
 
 module.exports = {
   name: require('./package').name,
@@ -27,6 +30,10 @@ module.exports = {
     let ember = this.project.findAddonByName('ember-source');
 
     this.templateCompilerPath = ember.absolutePaths.templateCompiler;
+  },
+
+  postBuild() {
+    maybePrintHbsDeprecation();
   },
 
   setupPreprocessorRegistry(type, registry) {

--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -1,7 +1,6 @@
 'use strict';
 require('validate-peer-dependencies')(__dirname);
 
-let stew = require('broccoli-stew');
 let VersionChecker = require('ember-cli-version-checker');
 let { addPlugin, hasPlugin } = require('ember-cli-babel-plugin-helpers');
 const { maybePrintHbsDeprecation } = require('./src/hbs-deprecation');

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "babel-import-util": "^0.2.0",
     "broccoli-stew": "^3.0.0",
+    "chalk": "^4.0.0",
     "ember-cli-babel-plugin-helpers": "^1.1.1",
     "ember-cli-version-checker": "^5.1.2",
     "line-column": "^1.0.2",

--- a/src/babel-plugin.js
+++ b/src/babel-plugin.js
@@ -2,7 +2,6 @@ const { ImportUtil } = require('babel-import-util');
 const util = require('../lib/util');
 const { transformTemplateLiteral } = require('./template-literal-transform');
 const { transformTemplateTag } = require('./template-tag-transform');
-const { addViolator } = require('./hbs-deprecation');
 
 /**
  * This Babel plugin takes parseable code emitted by the string-based

--- a/src/babel-plugin.js
+++ b/src/babel-plugin.js
@@ -1,3 +1,4 @@
+const chalk = require('chalk');
 const { ImportUtil } = require('babel-import-util');
 const util = require('../lib/util');
 const { transformTemplateLiteral } = require('./template-literal-transform');
@@ -92,6 +93,7 @@ module.exports = function (babel) {
 
     CallExpression(path, state) {
       if (util.isTemplateLiteral(path)) {
+        maybePrintHbsDeprecation();
         state.hadTaggedTemplate = true;
         transformTemplateLiteral(t, path, state);
       } else if (util.isTemplateTag(path)) {
@@ -102,3 +104,34 @@ module.exports = function (babel) {
 
   return { visitor };
 };
+
+/**
+ * Flip this after the first print, because otherwise,
+ * the deprecation will print for every occurrence of hbs.
+ *
+ * Ideally, if we could aggregate all the file paths that use hbs
+ * and then print the warning at the end, we'd have a nicer to-do list for folks to migrate.
+ */
+let hasPrintedHbsDeprecation = false;
+
+function deprecate(msg) {
+  /**
+   * Surrounding newlines are because this output occurs during the
+   * "building..." output of ember-cli, and interlacing
+   * dynamic output with static output does not look great normally.
+   */
+  console.warn(
+    '\n' + chalk.yellow(`DEPRECATION [ember-template-imports]: ${msg}`) + '\n'
+  );
+}
+
+function maybePrintHbsDeprecation() {
+  if (hasPrintedHbsDeprecation) return;
+
+  deprecate(
+    `importing 'hbs' from 'ember-template-imports' is deprecated and will be removed in the next major (v4.0.0). ` +
+      `Please migrate to the <template> syntax per the conclusions in https://github.com/emberjs/rfcs/pull/779.`
+  );
+
+  hasPrintedHbsDeprecation = true;
+}

--- a/src/hbs-deprecation.js
+++ b/src/hbs-deprecation.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const chalk = require('chalk');
+
+/**
+ * Flip this after the first print, because otherwise,
+ * the deprecation will print for every occurrence of hbs.
+ *
+ * The printing of these deprecations is per-tree,
+ * so it's possible to print multiple times accidentally.
+ */
+let hasPrintedHbsDeprecation = false;
+/**
+ * Boolean we flip on first violation.
+ * In case filenames are unavailable, we can still print the deprecation.
+ */
+let violatorFound = false;
+
+let violators = new Set();
+
+function addViolator(filePath) {
+  violators.add(filePath);
+  violatorFound = true;
+}
+
+function deprecate(msg) {
+  /**
+   * Surrounding newlines are because this output occurs during the
+   * "building..." output of ember-cli, and interlacing
+   * dynamic output with static output does not look great normally.
+   */
+  console.warn(
+    '\n\n' + chalk.yellow(`DEPRECATION [ember-template-imports]: ${msg}`) + '\n'
+  );
+}
+
+function maybePrintHbsDeprecation() {
+  if (!violatorFound) return;
+  if (hasPrintedHbsDeprecation) return;
+
+  deprecate(
+    `importing 'hbs' from 'ember-template-imports' is deprecated and will be removed in the next major (v4.0.0). ` +
+      `Please migrate to the <template> syntax per the conclusions in https://github.com/emberjs/rfcs/pull/779.` +
+      `\n\n` +
+      `\tViolators:\n\n\t` +
+      [...violators.entries()].join('\n\t')
+  );
+
+  hasPrintedHbsDeprecation = true;
+}
+
+module.exports = {
+  maybePrintHbsDeprecation,
+  addViolator,
+};

--- a/src/preprocess-embedded-templates.ts
+++ b/src/preprocess-embedded-templates.ts
@@ -19,6 +19,7 @@ interface PreprocessOptionsEager {
   relativePath: string;
   includeSourceMaps: boolean;
   includeTemplateTokens: boolean;
+  addViolator?: (relativePath: string) => void;
 }
 
 interface PreprocessOptionsLazy {
@@ -229,7 +230,7 @@ export function preprocessEmbeddedTemplates(
       match.tagName === importIdentifier
     ) {
       // hbs literals are deprecated
-      addViolator(relativePath);
+      addViolator?.(relativePath);
 
       replacements.push(
         ...replaceMatch(

--- a/src/preprocess-embedded-templates.ts
+++ b/src/preprocess-embedded-templates.ts
@@ -33,6 +33,7 @@ interface PreprocessOptionsLazy {
   relativePath: string;
   includeSourceMaps: boolean;
   includeTemplateTokens: boolean;
+  addViolator?: (relativePath: string) => void;
 }
 
 type PreprocessOptions = PreprocessOptionsLazy | PreprocessOptionsEager;
@@ -191,6 +192,7 @@ export function preprocessEmbeddedTemplates(
     includeSourceMaps,
     includeTemplateTokens,
     relativePath,
+    addViolator,
   } = options;
 
   const { importIdentifier } = options;
@@ -226,6 +228,9 @@ export function preprocessEmbeddedTemplates(
       match.type === 'template-literal' &&
       match.tagName === importIdentifier
     ) {
+      // hbs literals are deprecated
+      addViolator(relativePath);
+
       replacements.push(
         ...replaceMatch(
           s,

--- a/src/preprocessor-plugin.js
+++ b/src/preprocessor-plugin.js
@@ -1,5 +1,6 @@
 const stew = require('broccoli-stew');
 const util = require('../lib/util');
+const { addViolator } = require('./hbs-deprecation');
 const {
   preprocessEmbeddedTemplates,
 } = require('../lib/preprocess-embedded-templates');
@@ -70,6 +71,7 @@ module.exports = class TemplateImportPreprocessor {
 
       includeSourceMaps: true,
       includeTemplateTokens: true,
+      addViolator,
     };
   }
 


### PR DESCRIPTION
Example:
![image](https://user-images.githubusercontent.com/199018/227589874-4d8d17f4-56be-4b3c-aef4-128b10a03856.png)

Output of booting the test app:
```
DEPRECATION [ember-template-imports]: importing 'hbs' from 'ember-template-imports' is deprecated and will be removed in the next major (v4.0.0). Please migrate to the <template> syntax per the conclusions in https://github.com/emberjs/rfcs/pull/779.

	Violators:

	dummy/components/hbs-test.js,dummy/components/hbs-test.js
	dummy/tests/integration/hbs-test.js,dummy/tests/integration/hbs-test.js
```