### PR TITLE
Incorrectly parses some regular expressions

### DIFF
--- a/tests/integration/gjs-test.gjs
+++ b/tests/integration/gjs-test.gjs
@@ -100,4 +100,9 @@ module('tests/integration/components/gjs', function (hooks) {
 
     assert.equal(this.element.textContent.trim(), 'Hello, world!');
   });
+
+  test('it is not confused by a template-tag-like regex', async function (assert) {
+    let pattern = /<template\s*>/;
+    assert.ok(pattern);
+  });
 });


### PR DESCRIPTION
This adds a failing test for a case where we incorrectly interpret a regular expression as a template tag.