### PR TITLE
set moduleName to relativePath

### DIFF
--- a/__tests__/preprocess-embedded-templates.test.ts
+++ b/__tests__/preprocess-embedded-templates.test.ts
@@ -15,7 +15,8 @@ describe('preprocessEmbeddedTemplates', function () {
     });
 
     const expected = {
-      output: '[__GLIMMER_TEMPLATE(`Hello!`, { strictMode: true })]',
+      output:
+        "[__GLIMMER_TEMPLATE(`Hello!`, { strictMode: true, moduleName: 'foo.gjs' })]",
       replacements: [
         {
           type: 'start',
@@ -29,7 +30,7 @@ describe('preprocessEmbeddedTemplates', function () {
           type: 'end',
           index: 16,
           oldLength: 11,
-          newLength: 25,
+          newLength: 48,
           originalCol: 17,
           originalLine: 1,
         },
@@ -52,7 +53,7 @@ describe('preprocessEmbeddedTemplates', function () {
 
     const expected = {
       output:
-        '[__GLIMMER_TEMPLATE(`Hello \\`world\\`!`, { strictMode: true })]',
+        "[__GLIMMER_TEMPLATE(`Hello \\`world\\`!`, { strictMode: true, moduleName: 'foo.gjs' })]",
       replacements: [
         {
           type: 'start',
@@ -66,7 +67,7 @@ describe('preprocessEmbeddedTemplates', function () {
           type: 'end',
           index: 24,
           oldLength: 11,
-          newLength: 25,
+          newLength: 48,
           originalCol: 25,
           originalLine: 1,
         },
@@ -135,7 +136,7 @@ describe('preprocessEmbeddedTemplates', function () {
 
     const expected = {
       output:
-        "import { hbs } from 'ember-template-imports'\nconst Greeting = hbs(`Hello!`, { strictMode: true })\n",
+        "import { hbs } from 'ember-template-imports'\nconst Greeting = hbs(`Hello!`, { strictMode: true, moduleName: 'foo.gjs' })\n",
       replacements: [
         {
           type: 'start',
@@ -149,7 +150,7 @@ describe('preprocessEmbeddedTemplates', function () {
           type: 'end',
           index: 72,
           oldLength: 1,
-          newLength: 24,
+          newLength: 47,
           originalCol: 28,
           originalLine: 2,
         },

--- a/src/preprocess-embedded-templates.ts
+++ b/src/preprocess-embedded-templates.ts
@@ -112,7 +112,8 @@ function replaceMatch(
   endReplacement: string,
   template: string,
   getTemplateLocals: GetTemplateLocals,
-  includeTemplateTokens: boolean
+  includeTemplateTokens: boolean,
+  relativePath: string
 ): Replacement[] {
   const { start: openStart, end: openEnd } = getMatchStartAndEnd(match.start);
   const { start: closeStart, end: closeEnd } = getMatchStartAndEnd(match.end);
@@ -130,7 +131,7 @@ function replaceMatch(
   }
 
   const newStart = `${startReplacement}\``;
-  const newEnd = `\`, { strictMode: true${options} }${endReplacement}`;
+  const newEnd = `\`, { strictMode: true, moduleName: '${relativePath}'${options} }${endReplacement}`;
 
   s.overwrite(openStart, openEnd, newStart);
   s.overwrite(closeStart, closeEnd, newEnd);
@@ -234,7 +235,8 @@ export function preprocessEmbeddedTemplates(
           ')',
           template,
           getTemplateLocals,
-          includeTemplateTokens
+          includeTemplateTokens,
+          relativePath
         )
       );
     } else if (match.type === 'template-tag') {
@@ -246,7 +248,8 @@ export function preprocessEmbeddedTemplates(
           ')]',
           template,
           getTemplateLocals,
-          includeTemplateTokens
+          includeTemplateTokens,
+          relativePath
         )
       );
     }

--- a/tests/integration/gjs-test.gjs
+++ b/tests/integration/gjs-test.gjs
@@ -19,6 +19,7 @@ module('tests/integration/components/gjs', function (hooks) {
       })
     );
 
+    assert.equal(Foo.moduleName, 'gjs-test');
     assert.equal(this.element.textContent.trim(), 'Hello, world!');
   });
 


### PR DESCRIPTION
set moduleName to relativePath, like its done in [ember-cli-htmlbars](https://github.com/ember-cli/ember-cli-htmlbars/blob/master/lib/template-compiler-plugin.js#L22) otherwise it will use the filename, which might be less helpful (and I argue that the filename is not a moduleName, although it can be, but with all the (possible) linking (symbolic, hard link etc) in between I do not think it makes sense), especially when using pnpm the paths will be too long. see https://github.com/emberjs/ember-inspector/issues/2425