### PR TITLE
Update README for eslintrc configuration for test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ linting tools will work correctly.
 [etl]: https://github.com/ember-template-lint/ember-template-lint
 [epe]: https://github.com/ember-cli/eslint-plugin-ember
 
+For eslint, update the file extensions that eslint
+checks for your test files in the `.eslintrc` file
+```js
+{
+  // test files
+  files: ['tests/**/*-test.{js,ts,gjs,gts}'],
+  extends: ['plugin:qunit/recommended'],
+},
+```
+
 Additionally, if you are using TypeScript, you will also want to set up
 [Glint][glint], following [its setup instructions][glint-setup]. (Make sure you
 include `@glint/environment-ember-template-imports`!)


### PR DESCRIPTION
This updates the README with instructions to add the additional extensions (gjs,gts) to to the `eslintrc` test file configuration block. 


I assume that app files that are JS are just included, as I dont see any notation in the `eslintrc` file of a newly created app https://github.com/ember-cli/ember-cli/blob/master/blueprints/app/files/.eslintrc.js so I guess they are just included by default. I see the section for adding typescript files. Why are test files treated so differently?

Also assume a PR should be made to the default blueprint to just add gjs,gts for the test files. 