### PR TITLE
Update try scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           node-version: 16.x
       - name: install dependencies
         run: yarn install
+      - name: build
+        run: yarn build
       - name: lint:js
         run: yarn lint:js
       - name: lint:hbs
@@ -40,6 +42,8 @@ jobs:
       - name: install dependencies
         # Dependency fetching in Windows Actions runners can be slow
         run: yarn install --network-timeout 60000
+      - name: build
+        run: yarn build
       - name: ember test
         run: yarn test:ember
 
@@ -63,6 +67,8 @@ jobs:
       - name: install dependencies
         # Dependency fetching in Windows Actions runners can be slow
         run: yarn install --network-timeout 60000
+      - name: build
+        run: yarn build
       - name: ember test
         run: yarn test:ember
 
@@ -85,6 +91,8 @@ jobs:
       - name: install dependencies
         # Dependency fetching in Windows Actions runners can be slow
         run: yarn install --network-timeout 60000
+      - name: build
+        run: yarn build
       - name: ember test
         run: yarn test:ember
 
@@ -102,6 +110,8 @@ jobs:
           node-version: 16.x
       - name: install dependencies
         run: yarn install --ignore-lockfile
+      - name: build
+        run: yarn build
       - name: ember test
         run: yarn test:ember
 
@@ -133,6 +143,8 @@ jobs:
           node-version: 16.x
       - name: install dependencies
         run: yarn install
+      - name: build
+        run: yarn build
       - name: test
         env:
           EMBER_TRY_SCENARIO: ${{ matrix.ember-try-scenario }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: install dependencies
         run: yarn install
-      - name: build
-        run: yarn build
       - name: lint:js
         run: yarn lint:js
       - name: lint:hbs
@@ -35,17 +33,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: install dependencies
         # Dependency fetching in Windows Actions runners can be slow
         run: yarn install --network-timeout 60000
-      - name: build
-        run: yarn build
-      - name: jest
-        run: yarn test:jest
       - name: ember test
         run: yarn test:ember
 
@@ -62,17 +56,13 @@ jobs:
         node-version: [16.x, 18.x]
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: install dependencies
         # Dependency fetching in Windows Actions runners can be slow
         run: yarn install --network-timeout 60000
-      - name: build
-        run: yarn build
-      - name: jest
-        run: yarn test:jest
       - name: ember test
         run: yarn test:ember
 
@@ -88,17 +78,13 @@ jobs:
         os: [macos, windows]
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: install dependencies
         # Dependency fetching in Windows Actions runners can be slow
         run: yarn install --network-timeout 60000
-      - name: build
-        run: yarn build
-      - name: jest
-        run: yarn test:jest
       - name: ember test
         run: yarn test:ember
 
@@ -110,16 +96,12 @@ jobs:
     needs: [test, lint]
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: install dependencies
         run: yarn install --ignore-lockfile
-      - name: build
-        run: yarn build
-      - name: jest
-        run: yarn test:jest
       - name: ember test
         run: yarn test:ember
 
@@ -135,21 +117,22 @@ jobs:
       matrix:
         ember-try-scenario:
           - ember-3.27
+          - ember-4.12
           - ember-release
           - ember-beta
           - ember-canary
-          - embroider-safe
-          - embroider-optimized
+          - embroider-safe-min-supported
+          - embroider-optimized-min-supported
+          - embroider-safe-release
+          - embroider-optimized-release
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: 16.x
       - name: install dependencies
         run: yarn install
-      - name: build
-        run: yarn build
       - name: test
         env:
           EMBER_TRY_SCENARIO: ${{ matrix.ember-try-scenario }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         run: yarn install --network-timeout 60000
       - name: build
         run: yarn build
+      - name: jest
+        run: yarn test:jest
       - name: ember test
         run: yarn test:ember
 
@@ -69,6 +71,8 @@ jobs:
         run: yarn install --network-timeout 60000
       - name: build
         run: yarn build
+      - name: jest
+        run: yarn test:jest
       - name: ember test
         run: yarn test:ember
 
@@ -93,6 +97,8 @@ jobs:
         run: yarn install --network-timeout 60000
       - name: build
         run: yarn build
+      - name: jest
+        run: yarn test:jest
       - name: ember test
         run: yarn test:ember
 
@@ -112,6 +118,8 @@ jobs:
         run: yarn install --ignore-lockfile
       - name: build
         run: yarn build
+      - name: jest
+        run: yarn test:jest
       - name: ember test
         run: yarn test:ember
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,6 +4,18 @@ const getChannelURL = require('ember-source-channel-url');
 const { embroiderSafe, embroiderOptimized } = require('@embroider/test-setup');
 
 module.exports = async function () {
+  const ember5Deps = {
+    '@ember/string': '^3.1.1',
+    '@ember/test-helpers': '^3.2.0',
+    'ember-qunit': '^7.0.0',
+    'ember-resolver': '^11.0.0',
+    'ember-auto-import': '^2.3.0',
+    'ember-cli': '^5.1.0',
+    'ember-maybe-import-regenerator': null,
+  };
+
+  const release = await getChannelURL('release');
+
   return {
     useYarn: true,
     scenarios: [
@@ -16,10 +28,19 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-4.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.12.3',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {
-            'ember-source': await getChannelURL('release'),
+            'ember-source': release,
+            ...ember5Deps,
           },
         },
       },
@@ -28,6 +49,8 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
+            'ember-cli': '^5.0.0',
+            ...ember5Deps,
           },
         },
       },
@@ -36,11 +59,45 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
+            'ember-cli': '^5.0.0',
+            ...ember5Deps,
           },
         },
       },
-      embroiderSafe(),
-      embroiderOptimized(),
+      embroiderSafe({
+        name: 'embroider-safe-min-supported',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.27.0',
+          },
+        },
+      }),
+      embroiderOptimized({
+        name: 'embroider-optimized-min-supported',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.27.0',
+          },
+        },
+      }),
+      embroiderSafe({
+        name: 'embroider-safe-release',
+        npm: {
+          devDependencies: {
+            'ember-source': release,
+            ...ember5Deps,
+          },
+        },
+      }),
+      embroiderOptimized({
+        name: 'embroider-optimized-release',
+        npm: {
+          devDependencies: {
+            'ember-source': release,
+            ...ember5Deps,
+          },
+        },
+      }),
     ],
   };
 };


### PR DESCRIPTION
Extracted from: https://github.com/ember-template-imports/ember-template-imports/pull/187/files

Supports range: 3.27 -> ember-canary (v5)
adds range for embroider as well from min-supported to _release_.