### PR TITLE
Remove `ie 11` from browser targets in `dummy` app

### DIFF
--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions',
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
Should hopefully fix the failing CI runs, at least, this fixed it for `ember-page-title`.