### PR TITLE
Failures with imported modifiers and helpers repro

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ember-source": "~4.8.2",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^2.18.1",
+    "ember-truth-helpers": "^4.0.3",
     "ember-try": "^3.0.0",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ devDependencies:
   ember-template-lint:
     specifier: ^2.18.1
     version: 2.21.0
+  ember-truth-helpers:
+    specifier: ^4.0.3
+    version: 4.0.3(ember-source@4.8.6)
   ember-try:
     specifier: ^3.0.0
     version: 3.0.0
@@ -1549,6 +1552,17 @@ packages:
       calculate-cache-key-for-tree: 2.0.0
       ember-cli-babel: 7.26.11
       ember-cli-version-checker: 5.1.2
+      semver: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@embroider/addon-shim@1.8.6:
+    resolution: {integrity: sha512-siC9kP78uucEbpDcVyxjkwa76pcs5rVzDVpWO4PDc9EAXRX+pzmUuSTLAK3GztUwx7/PWhz1BenAivqdSvSgfg==}
+    engines: {node: 12.* || 14.* || >= 16}
+    dependencies:
+      '@embroider/shared-internals': 2.5.0
+      broccoli-funnel: 3.0.8
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -5893,6 +5907,24 @@ packages:
       - supports-color
     dev: true
 
+  /ember-cli-typescript@5.2.1:
+    resolution: {integrity: sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==}
+    engines: {node: '>= 12.*'}
+    dependencies:
+      ansi-to-html: 0.6.15
+      broccoli-stew: 3.0.0
+      debug: 4.3.4
+      execa: 4.1.0
+      fs-extra: 9.1.0
+      resolve: 1.22.8
+      rsvp: 4.8.5
+      semver: 7.5.4
+      stagehand: 1.0.1
+      walk-sync: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /ember-cli-version-checker@3.1.3:
     resolution: {integrity: sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -6110,6 +6142,20 @@ packages:
     engines: {node: '>= 0.10.0'}
     dev: true
 
+  /ember-functions-as-helper-polyfill@2.1.2(ember-source@4.8.6):
+    resolution: {integrity: sha512-yvW6xykvZEIYzzwlrC/g9yu6LtLkkj5F+ho6U+BDxN1uREMgoMOZnji7sSILn5ITVpaJ055DPcO+utEFD7IZOA==}
+    engines: {node: '>= 14.0.0'}
+    peerDependencies:
+      ember-source: ^3.25.0 || >=4.0.0
+    dependencies:
+      ember-cli-babel: 7.26.11
+      ember-cli-typescript: 5.2.1
+      ember-cli-version-checker: 5.1.2
+      ember-source: 4.8.6(@babel/core@7.23.2)(@glimmer/component@1.1.2)(webpack@5.89.0)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /ember-load-initializers@2.1.2(@babel/core@7.23.2):
     resolution: {integrity: sha512-CYR+U/wRxLbrfYN3dh+0Tb6mFaxJKfdyz+wNql6cqTrA0BBi9k6J3AaKXj273TqvEpyyXegQFFkZEiuZdYtgJw==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -6284,6 +6330,18 @@ packages:
       slash: 3.0.0
       tmp: 0.2.1
       workerpool: 6.5.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /ember-truth-helpers@4.0.3(ember-source@4.8.6):
+    resolution: {integrity: sha512-T6Ogd3pk9FxYiZfSxdjgn3Hb3Ksqgw7CD23V9qfig9jktNdkNEHo4+3PA3cSD/+3a2kdH3KmNvKyarVuzdtEkA==}
+    peerDependencies:
+      ember-source: '>=3.28.0'
+    dependencies:
+      '@embroider/addon-shim': 1.8.6
+      ember-functions-as-helper-polyfill: 2.1.2(ember-source@4.8.6)
+      ember-source: 4.8.6(@babel/core@7.23.2)(@glimmer/component@1.1.2)(webpack@5.89.0)
     transitivePeerDependencies:
       - supports-color
     dev: true

--- a/tests/dummy/app/components/with-modifier.gjs
+++ b/tests/dummy/app/components/with-modifier.gjs
@@ -1,0 +1,11 @@
+import { on } from '@ember/modifier';
+import Component from '@glimmer/component';
+
+export class WithModifier extends Component {
+  click = () => {};
+
+  <template>
+    <button type="button" {{on 'click' this.click}}>Click me</button>
+  </template>
+}
+

--- a/tests/dummy/app/utils/just-a-plain-class.js
+++ b/tests/dummy/app/utils/just-a-plain-class.js
@@ -1,0 +1,3 @@
+export class JustAPlainClass {
+  someState = 'someState';
+}

--- a/tests/integration/with-modifier-test.gts
+++ b/tests/integration/with-modifier-test.gts
@@ -45,11 +45,12 @@ module('tests/integration/components/gjs', function (hooks) {
     assert.equal(this.element.textContent.trim(), 'Click me');
   })
 
-  test('it renders a compoentn with a modifer with precompileTemplate', async function (assert) {
+  test('it renders a component with a modifer with precompileTemplate', async function (assert) {
     await render(precompileTemplate(`<WithModifier />`, {
       strictMode: true,
       scope: () => ({WithModifier, on})
     }));
+    assert.equal(this.element.textContent.trim(), 'Click me');
   })
 
   test('it renders a component with a helper', async function (assert) {

--- a/tests/integration/with-modifier-test.gts
+++ b/tests/integration/with-modifier-test.gts
@@ -6,6 +6,7 @@ import Component from '@glimmer/component';
 import { precompileTemplate } from '@ember/template-compilation';
 import {JustAPlainClass} from 'dummy/utils/just-a-plain-class';
 import { WithModifier } from 'dummy/components/with-modifier';
+import { eq } from 'ember-truth-helpers'
 
 class WithHelper extends Component {
   trueCondition = 'true';

--- a/tests/integration/with-modifier-test.gts
+++ b/tests/integration/with-modifier-test.gts
@@ -4,6 +4,7 @@ import { render } from '@ember/test-helpers';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import { precompileTemplate } from '@ember/template-compilation';
+import {JustAPlainClass} from 'dummy/utils/just-a-plain-class';
 
 class WithModifier extends Component {
   click = () => {};
@@ -20,6 +21,14 @@ class WithHelper extends Component {
     {{#if (eq this.trueCondition 'true')}}
       <div>TRUE</div>
     {{/if}}
+  </template>
+}
+
+class WithAnotherClass extends Component {
+  plainClass = new JustAPlainClass();
+
+  <template>
+    <div>{{this.plainClass.someState}}</div>
   </template>
 }
 
@@ -50,5 +59,14 @@ module('tests/integration/components/gjs', function (hooks) {
       </template>
     );
     assert.equal(this.element.textContent.trim(), 'TRUE');
+  })
+
+  test('it renders a component that consumes another class', async function (assert) {
+    await render(
+      <template>
+        <WithAnotherClass />
+      </template>
+    );
+    assert.equal(this.element.textContent.trim(), 'someState');
   })
 });

--- a/tests/integration/with-modifier-test.gts
+++ b/tests/integration/with-modifier-test.gts
@@ -5,14 +5,7 @@ import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
 import { precompileTemplate } from '@ember/template-compilation';
 import {JustAPlainClass} from 'dummy/utils/just-a-plain-class';
-
-class WithModifier extends Component {
-  click = () => {};
-
-  <template>
-    <button type="button" {{on 'click' this.click}}>Click me</button>
-  </template>
-}
+import { WithModifier } from 'dummy/components/with-modifier';
 
 class WithHelper extends Component {
   trueCondition = 'true';

--- a/tests/integration/with-modifier-test.gts
+++ b/tests/integration/with-modifier-test.gts
@@ -3,6 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { on } from '@ember/modifier';
 import Component from '@glimmer/component';
+import { precompileTemplate } from '@ember/template-compilation';
 
 class WithModifier extends Component {
   click = () => {};
@@ -12,6 +13,15 @@ class WithModifier extends Component {
   </template>
 }
 
+class WithHelper extends Component {
+  trueCondition = 'true';
+
+  <template>
+    {{#if (eq this.trueCondition 'true')}}
+      <div>TRUE</div>
+    {{/if}}
+  </template>
+}
 
 
 module('tests/integration/components/gjs', function (hooks) {
@@ -24,5 +34,21 @@ module('tests/integration/components/gjs', function (hooks) {
       </template>
     );
     assert.equal(this.element.textContent.trim(), 'Click me');
+  })
+
+  test('it renders a compoentn with a modifer with precompileTemplate', async function (assert) {
+    await render(precompileTemplate(`<WithModifier />`, {
+      strictMode: true,
+      scope: () => ({WithModifier, on})
+    }));
+  })
+
+  test('it renders a component with a helper', async function (assert) {
+    await render(
+      <template>
+        <WithHelper />
+      </template>
+    );
+    assert.equal(this.element.textContent.trim(), 'TRUE');
   })
 });

--- a/tests/integration/with-modifier-test.gts
+++ b/tests/integration/with-modifier-test.gts
@@ -1,0 +1,28 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { on } from '@ember/modifier';
+import Component from '@glimmer/component';
+
+class WithModifier extends Component {
+  click = () => {};
+
+  <template>
+    <button type="button" {{on 'click' this.click}}>Click me</button>
+  </template>
+}
+
+
+
+module('tests/integration/components/gjs', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders a component with a modifier', async function (assert) {
+    await render(
+      <template>
+        <WithModifier />
+      </template>
+    );
+    assert.equal(this.element.textContent.trim(), 'Click me');
+  })
+});


### PR DESCRIPTION
I recently updated to V4 of ember-template-imports, but have found widespread breakages across our app as a result.

It seems like the template compilation process isn't dealing properly with imported functions and other components, but plain classes seem to be ok.

This PR just adds failing tests to demonstrate the problem, I'm unsure how to fix, but happy to give it some time.

Screenshot from our CI

<img width="1110" alt="Screenshot 2023-10-19 at 11 41 29 am" src="https://github.com/ember-template-imports/ember-template-imports/assets/1583673/7223a7c7-024c-41cb-98b3-f8cdb6bb3fe0">
