### PR TITLE
Use `this.parent` instead of `this.project` when version checking

### DIFF
--- a/ember-addon-main.js
+++ b/ember-addon-main.js
@@ -9,10 +9,10 @@ module.exports = {
     this._super.included.apply(this, arguments);
 
     let emberChecker = new VersionChecker(this.project).for('ember-source');
-    let emberCliHtmlBars = new VersionChecker(this.project).for(
+    let emberCliHtmlBars = new VersionChecker(this.parent).for(
       'ember-cli-htmlbars',
     );
-    let emberCliBabel = new VersionChecker(this.project).for('ember-cli-babel');
+    let emberCliBabel = new VersionChecker(this.parent).for('ember-cli-babel');
 
     let errors = [];
 


### PR DESCRIPTION
This fixes the issue where the error messages are displayed when ember-template-imports is used by an addon and the host app doesn't have the expected versions installed.